### PR TITLE
Added missing whitespace to seperate the two headers

### DIFF
--- a/src/executors/credit/DeferredCreditExec.php
+++ b/src/executors/credit/DeferredCreditExec.php
@@ -37,7 +37,7 @@ class DeferredCreditExec
     static function deferredCredit(DeferredCreditRequest $request, PhonePeClientConfig $phonePeClientConfig) {
         $url = $phonePeClientConfig->mercuryBaseUrl . '/v1/credit/deferred';
         $args = array($request->merchantId, $request->transactionId, $request->amount, $request->header->salt->key, $request->header->salt->index);
-        $headers = 'Content-type:application/json ' . 'X-VERIFY:' . ChecksumGenerator::checkSumGenerate($args) . 'X-CALLBACK-URL:' . $request->header->callBackUri;
+        $headers = 'Content-type:application/json ' . 'X-VERIFY:' . ChecksumGenerator::checkSumGenerate($args) . ' X-CALLBACK-URL:' . $request->header->callBackUri;
         $responseArray = RequestGenerator::postRequest($url, $request, $headers);
         if ($responseArray[1]['http_code'] != 302) {
             $response = json_decode($responseArray[0]);

--- a/src/executors/credit/RegularCreditExec.php
+++ b/src/executors/credit/RegularCreditExec.php
@@ -39,7 +39,7 @@ class RegularCreditExec
     static function regularCredit(RegularCreditRequest $request, PhonePeClientConfig $phonePeClientConfig) {
         $url = $phonePeClientConfig->mercuryBaseUrl . '/v1/credit/';
         $args = array($request->merchantId, $request->transactionId, $request->amount, $request->header->salt->key, $request->header->salt->index);
-        $headers = 'Content-type:application/json ' . 'X-VERIFY:' . ChecksumGenerator::checkSumGenerate($args) . 'X-CALLBACK-URL:' . $request->header->callBackUri;
+        $headers = 'Content-type:application/json ' . 'X-VERIFY:' . ChecksumGenerator::checkSumGenerate($args) . ' X-CALLBACK-URL:' . $request->header->callBackUri;
         $responseArray = RequestGenerator::postRequest($url, $request, $headers);
         if ($responseArray[1]['http_code'] != 302) {
             $response = json_decode($responseArray[0]);

--- a/src/executors/debit/RegularDebitExec.php
+++ b/src/executors/debit/RegularDebitExec.php
@@ -41,7 +41,7 @@ class RegularDebitExec
     {
         $url = $phonePeClientConfig->mercuryBaseUrl . '/v1/debit/';
         $args = array($request->merchantId, $request->transactionId, $request->amount, $request->header->salt->key, $request->header->salt->index);
-        $headers = 'Content-type:application/json ' . 'X-VERIFY:' . ChecksumGenerator::checkSumGenerate($args) . 'X-CALLBACK-URL:' . $request->header->callBackUri;
+        $headers = 'Content-type:application/json ' . 'X-VERIFY:' . ChecksumGenerator::checkSumGenerate($args) . ' X-CALLBACK-URL:' . $request->header->callBackUri;
         $responseArray = RequestGenerator::postRequest($url, $request, $headers);
         if ($responseArray[1]['http_code'] != 302) {
             $response = json_decode($responseArray[0]);


### PR DESCRIPTION
The addition of X-CALLBACK-URL was missing a whitespace which caused it to be a part of X-VERIFY header which therefore caused the BAD_REQUEST error from the server